### PR TITLE
[zig 0.15.0] Update callconv(.C) -> callconv(.c)

### DIFF
--- a/src/Card.zig
+++ b/src/Card.zig
@@ -481,7 +481,7 @@ const SCardControl = @extern(*const fn (
     out_response_buf_ptr: [*]u8,
     response_buf_len: Uword,
     out_response_len: *Uword,
-) callconv(.C) Result, .{
+) callconv(.c) Result, .{
     .name = if (builtin.os.tag == .macos)
         "SCardControl132"
     else
@@ -495,7 +495,7 @@ const SCardControl112 = if (builtin.os.tag == .macos) @extern(
         cbSendLength: Uword,
         pbRecvBuffer: [*]u8,
         pcbRecvLength: *Uword,
-    ) callconv(.C) Result,
+    ) callconv(.c) Result,
     .{
         .name = "SCardControl",
     },
@@ -539,7 +539,7 @@ const SCardStatus = switch (builtin.os.tag) {
         out_active_protocol: *Protocol.Sys,
         out_atr_ptr: [*]u8,
         out_atr_len: *Uword,
-    ) callconv(.C) Result, .{
+    ) callconv(.c) Result, .{
         .name = "SCardStatusA",
     }),
 
@@ -551,7 +551,7 @@ const SCardStatus = switch (builtin.os.tag) {
         out_active_protocol: *Protocol.Sys,
         out_atr_ptr: [*]u8,
         out_atr_len: *Uword,
-    ) callconv(.C) Result, .{
+    ) callconv(.c) Result, .{
         .name = "SCardStatus",
     }),
 };

--- a/src/Client.zig
+++ b/src/Client.zig
@@ -295,7 +295,7 @@ const SCardConnect = @extern(*const fn (
     preferred_protocol: Protocol.Sys,
     out_card: *Card.Handle,
     out_active_protocol: *Protocol.Sys,
-) callconv(.C) Result, .{
+) callconv(.c) Result, .{
     .name = if (builtin.os.tag == .windows)
         "SCardConnectA"
     else
@@ -314,7 +314,7 @@ const SCardGetStatusChange = @extern(*const fn (
     timeout: Uword,
     in_out_readers_ptr: [*]const Reader,
     readers_len: Uword,
-) callconv(.C) Result, .{
+) callconv(.c) Result, .{
     .name = if (builtin.os.tag == .windows)
         "SCardGetStatusChangeA"
     else
@@ -327,7 +327,7 @@ const SCardListReaderGroups = @extern(*const fn (
     client: Client.Handle,
     out_group_names_combined: ?[*]u8,
     in_out_group_names_len: *Uword,
-) callconv(.C) Result, .{
+) callconv(.c) Result, .{
     .name = if (builtin.os.tag == .windows)
         "SCardListReaderGroupsA"
     else
@@ -341,7 +341,7 @@ const SCardListReaders = @extern(*const fn (
     group_name: ?[*:0]const u8,
     out_reader_names_combined: ?[*]u8,
     in_out_reader_names_len: *Uword,
-) callconv(.C) Result, .{
+) callconv(.c) Result, .{
     .name = if (builtin.os.tag == .windows)
         "SCardListReadersA"
     else


### PR DESCRIPTION
Updates for compatibility with both Zig 0.14.1 and 0.15.0 (as of 07/20).