### PR TITLE
[CI] Switch to mlugg/setup-zig and lock zig version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,9 @@ jobs:
     env:
       FORCE_COLOR: 1
     steps:
-      - name: Install ZVM
-        run: |
-          curl https://raw.githubusercontent.com/tristanisham/zvm/master/install.sh | bash
-          echo PATH="~/.zvm/self:~/.zvm/bin:$PATH" >> "$GITHUB_ENV"
-
-      - name: Install Zig
-        run: |
-          zvm install master
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.0-dev.1283+1fcaf90dd
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,14 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_name == 'main'
     steps:
-      - name: Install ZVM
-        run: |
-          curl https://raw.githubusercontent.com/tristanisham/zvm/master/install.sh | bash
-          echo PATH="~/.zvm/self:~/.zvm/bin:$PATH" >> "$GITHUB_ENV"
-
-      - name: Install Zig
-        run: |
-          zvm install master
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.0-dev.1283+1fcaf90dd
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Was previously always installing zig@latest via ZVM, but something's broken on main with the way dependencies are fetched, so switching to `mlugg/setup-zig` and locking to a version matching `.zigversion`.