### PR TITLE
[CI] Update Zig version to match base-z autodoc version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.16.0-dev.1484+d0ba6642b
+          version: 0.16.0-dev.1890+2bd02883c
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.16.0-dev.1484+d0ba6642b
+          version: 0.16.0-dev.1890+2bd02883c
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
**Fix doc generation step in CI:**
Making sure we're running with a Zig version compatible with the current `base-z`.

**TODO:**
Need to enable the doc generation job for non-`main` branches as well and skip just the publish step instead.