### PR TITLE
[chore] Readme: Update Zig-0.15 installation URI to new zig-0.15 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ zig fetch --save=pcsc "git+https://github.com/kofi-q/pcsc-z.git"
 > To use a 0.15.*-compatible version, you can fetch the following commit instead:
 
 ```sh
-zig fetch --save=pcsc "git+https://github.com/kofi-q/pcsc-z.git#72ca6c7a07f4ec7d42dee3502b7ccdb5993b3858"
+zig fetch --save=pcsc "git+https://github.com/kofi-q/pcsc-z.git#zig-0.15"
 ```
 
 ## Build Configuration

--- a/build.zig
+++ b/build.zig
@@ -20,7 +20,6 @@ pub fn build(b: *std.Build) !void {
         \\cross-compiling to non-native Linux/MacOS targets.
         ,
     );
-    std.log.info("link sysroots: {?}", .{link_vendored_sysroots});
 
     const steps = Steps{
         .check = b.step("check", "Get compile-time diagnostics"),


### PR DESCRIPTION
Created a [zig-0.15](https://github.com/kofi-q/pcsc-z/tree/zig-0.15) branch to provide an installation target for Zig-0.15-compatible versions. Updating the README accordingly.

Also removing a stray debug log in the build script.