### PR TITLE
Update example code to avoid edge case error with no readers connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ pub fn main() !void {
     );
 
     // Detect connected card readers:
-    var readers = [_]pcsc.Reader{.empty};
+    var readers = [_]pcsc.Reader{.pnp_query};
     while (true) {
         var reader_names = try client.readerNames();
         if (reader_names.next()) |name| {
@@ -127,7 +127,7 @@ pub fn main() !void {
 
         std.debug.print("Connect a reader to continue...\n", .{});
 
-        try client.waitForUpdates(&[_]pcsc.Reader{.pnp_query}, .infinite);
+        try client.waitForUpdates(&readers, .infinite);
     }
 
     // Detect inserted cards:

--- a/examples/transmit/main.zig
+++ b/examples/transmit/main.zig
@@ -9,7 +9,7 @@ pub fn main() !void {
     );
 
     // Detect connected card readers:
-    var readers = [_]pcsc.Reader{.empty};
+    var readers = [_]pcsc.Reader{.pnp_query};
     while (true) {
         var reader_names = try client.readerNames();
         if (reader_names.next()) |name| {
@@ -20,7 +20,7 @@ pub fn main() !void {
 
         std.debug.print("Connect a reader to continue...\n", .{});
 
-        try client.waitForUpdates(&[_]pcsc.Reader{.pnp_query}, .infinite);
+        try client.waitForUpdates(&readers, .infinite);
     }
 
     // Detect inserted cards:


### PR DESCRIPTION
Noticed while testing on Debian 13 that the initial PNP query in the example fails (when no readers are connected) - looks like an issue with an attempted mutation of the constant PNP query array, which doesn't repro on Debian 12 or MacOS, AFAICT.
Moving the PNP query to the mutable array instead to avoid the error. Also need to follow up with an update to the `Client.waitForUpdates()` API and associated binding to require mutability at the type level.